### PR TITLE
Fix on demand file issues regarding x-client-transaction-id

### DIFF
--- a/graphql_api.py
+++ b/graphql_api.py
@@ -48,7 +48,7 @@ class GraphqlAPI():
     def init_client_transaction(cls):
         session = requests.Session()
         session.headers = generate_headers()
-        home_page = session.get(url="https://x.com")
+        home_page = session.get(url="https://x.com/home")
         home_page_response = bs4.BeautifulSoup(home_page.content, 'html.parser')
         ondemand_file_url = get_ondemand_file_url(response=home_page_response)
         ondemand_file = session.get(url=ondemand_file_url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests
 httpx
 XClientTransaction>=1.0.1
 brotli
+setuptools<81


### PR DESCRIPTION
Change initial home page request to /home to fix ondemand file lookup.

Reported in isarabjitdhiman/XClientTransaction#38
Fixed by isarabjitdhiman/XClientTransaction#39

Also pinned Setuptools<81.

UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.